### PR TITLE
Support asynchronous sequential dispatches.

### DIFF
--- a/examples/counter/actions/notification.js
+++ b/examples/counter/actions/notification.js
@@ -7,3 +7,14 @@ export function notifyTop(caller) {
     dispatch({ type: NOTIFY_TOP, caller: caller });
   };
 }
+
+export function delayedNotifyTop(caller, delay = 1000) {
+  return (dispatch, getState) => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        dispatch({ type: NOTIFY_TOP, caller: caller });
+        resolve();
+      }, delay)
+    });
+  };
+}

--- a/examples/counter/events/notifyEvents.js
+++ b/examples/counter/events/notifyEvents.js
@@ -1,11 +1,11 @@
 import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/counter';
-import { notifyTop } from '../actions/notification';
+import { notifyTop, delayedNotifyTop } from '../actions/notification';
 import { notifySnackbar } from '../actions/snackbar';
 
 const events = [
   {
     catch: [INCREMENT_COUNTER, DECREMENT_COUNTER],
-    dispatch: [notifyTop, notifySnackbar]
+    dispatch: [delayedNotifyTop, notifySnackbar]
   }
 ];
 

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -23,7 +23,7 @@
     "react-redux": "^4.0.0",
     "react-toolbox": "^0.11.5",
     "redux": "^3.0.0",
-    "redux-notify": "^0.1.1",
+    "redux-notify": "file:../../",
     "redux-thunk": "^0.1.0"
   },
   "devDependencies": {
@@ -38,7 +38,7 @@
     "jsdom": "^5.6.1",
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "~3.4.2",
     "normalize.css": "^3.0.3",
     "postcss": "^5.0.12",
     "postcss-loader": "^0.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,13 @@
+function isPromise(obj) {
+  return !!obj
+    && (typeof obj === 'object' || typeof obj === 'function')
+    && typeof obj.then === 'function'
+    && typeof obj.catch === 'function';
+}
+
 const notify = (events, config) => ({ dispatch }) => next => action => {
+  let promiseChain;
+
   events.forEach( event => {
     if (event.catch.indexOf(action.type) !== -1) {
       if (config && config.noReverse) {
@@ -9,7 +18,20 @@ const notify = (events, config) => ({ dispatch }) => next => action => {
         setTimeout(() => { dispatch(event.dispatch(action)) }, 0);
       }
       else if (event.dispatch instanceof Array) {
-        event.dispatch.forEach( fn => setTimeout(() => { dispatch(fn(action)) }, 0) );
+        event.dispatch.forEach( fn => {
+          setTimeout(() => {
+            if (isPromise(promiseChain)) {
+              promiseChain = promiseChain
+                .then(() => dispatch(fn(action)))
+                .catch(e => {throw new Error(e)});
+            } else {
+              const res = dispatch(fn(action));
+              if (isPromise(res)) {
+                promiseChain = res;
+              }
+            }
+          }, 0);
+        });
       }
       else throw new Error('Expected dispatch value to be a function or an array of functions.');
     }


### PR DESCRIPTION
In my latest project, the need for dispatching multiple asynchronous action creators sequentially came up. 

Image a scenario where every dispatched action should call a refresh token action before executing. As shown in the following snippet, instead of repeating the refresh logic in every action creator, it's better to dispatch the refresh action first, wait for its completion and then trigger the next action.

`export default [{
  catch: [FETCH_DATA],
  dispatch: [refreshToken, fetchData]
}]
`

As a result, i've tweaked redux-notify to support asynchronous sequential execution of dispatched actions that return ES6 native promises. If a promise fails, an error will be triggered. 

To test the new behavior, please run the counter example.

Thanks.
